### PR TITLE
fix(IE11): remove Object.assign

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,21 @@ export Value from './components/Value'
 export compose from './utils/compose'
 export renderProps from './utils/renderProps'
 
-const all = Object.assign({}, exports)
-delete all.default
-
-export default all
+export default {
+  Active,
+  Bind,
+  Compose,
+  Counter,
+  Focus,
+  Form,
+  Hover,
+  Index,
+  List,
+  Loading,
+  Set,
+  State,
+  Toggle,
+  Value,
+  compose,
+  renderProps,
+}


### PR DESCRIPTION
Fix for https://github.com/renatorib/react-powerplug/issues/21. @renatorib does this seem like a safe change? I wasn't sure if there was something with `.default` I needed to do.