### PR TITLE
Removed default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,22 +34,3 @@ export {
   compose,
   renderProps,
 }
-
-export default {
-  Active,
-  Bind,
-  Compose,
-  Counter,
-  Focus,
-  Form,
-  Hover,
-  Index,
-  List,
-  Loading,
-  Set,
-  State,
-  Toggle,
-  Value,
-  compose,
-  renderProps,
-}


### PR DESCRIPTION
Exporting such default export is an anti-pattern of sorts. It exports a single object (where `export { 
A, B }` exports specifiers/bindings) which cannot be later tree-shaken - so by using this:
```js
import Powerplug from 'react-powerplug'

// ...

render() {
  return <Powerplug.Hover />
}
```
you drag every single utility from `Powerplug` into a consuming bundle.