### PR TITLE
Add List first and last element accessors

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -2,22 +2,25 @@ import React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
-const complement = fn =>
-  (...args) => !fn(...args)
+const complement = fn => (...args) => !fn(...args)
 
 const List = ({ initial = [], onChange, ...props }) => (
-  <State initial={{ list: initial }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      list: state.list,
-      setList: (list) =>
-        setState({ list }),
-      push: (value) =>
-        setState(({ list }) => ({ list: [...list, value] })),
-      pull: (predicate) =>
-        setState(({ list }) => ({ list: list.filter(complement(predicate)) })),
-      sort: (compareFn) =>
-        setState(({ list }) => ({ list: [...list].sort(compareFn) })),
-    })}
+  <State initial={{ list: initial }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        list: state.list,
+        first: () => state.list[0],
+        last: () => state.list[Math.max(0, state.list.length - 1)],
+        setList: list => setState({ list }),
+        push: value => setState(({ list }) => ({ list: [...list, value] })),
+        pull: predicate =>
+          setState(({ list }) => ({
+            list: list.filter(complement(predicate)),
+          })),
+        sort: compareFn =>
+          setState(({ list }) => ({ list: [...list].sort(compareFn) })),
+      })
+    }
   </State>
 )
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -112,6 +112,8 @@ type ListChange<T> = ({| list: $ReadOnlyArray<T> |}) => void
 
 type ListRender<T> = ({|
   list: $ReadOnlyArray<T>,
+  first: () => T | void,
+  last: () => T | void,
   setList: ($ReadOnlyArray<T>) => void,
   push: (value: T) => void,
   pull: (predicate: (T) => boolean) => void,

--- a/tests/components/List.test.js
+++ b/tests/components/List.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import * as plug from '../../src'
+import { last } from './utils'
+
+test('<List />', () => {
+  const renderFn = jest.fn().mockReturnValue(null)
+  TestRenderer.create(<plug.List initial={[1]} render={renderFn} />)
+  const lastCalled = () => last(renderFn.mock.calls)[0]
+
+  expect(renderFn).toHaveBeenCalledTimes(1)
+  expect(lastCalled().list).toEqual([1])
+
+  lastCalled().push(8)
+  expect(lastCalled().list).toEqual([1, 8])
+
+  lastCalled().setList([5, 4, 1, 6, 9])
+  expect(lastCalled().list).toEqual([5, 4, 1, 6, 9])
+
+  const listBeforeSort = lastCalled().list
+  lastCalled().sort()
+  expect(lastCalled().list).toEqual([1, 4, 5, 6, 9])
+  expect(listBeforeSort).toEqual([5, 4, 1, 6, 9])
+
+  lastCalled().pull(d => d % 2)
+  expect(lastCalled().list).toEqual([4, 6])
+
+  expect(lastCalled().first()).toEqual(4)
+  expect(lastCalled().last()).toEqual(6)
+  lastCalled().setList([])
+  expect(lastCalled().first()).toEqual(undefined)
+  expect(lastCalled().last()).toEqual(undefined)
+})

--- a/tests/test_flow.js
+++ b/tests/test_flow.js
@@ -218,8 +218,10 @@ const noop = () => null
 }
 
 {
-  const render = ({ list, setList, push, pull, sort }) => {
+  const render = ({ list, first, last, setList, push, pull, sort }) => {
     ;(list: $ReadOnlyArray<number>)
+    ;(first(): string | number | void)
+    ;(last(): string | number | void)
     setList([])
     setList([0])
     push(0)


### PR DESCRIPTION
Getting last element is always noisy. That's why there's [new proposal](https://github.com/prettydiff/Array.prototype.last).
Here's `last()` getter and symmetric `first()`.
Also added optimization `list[Math.max(0, list.length - 1)]` which prevents index out of range.