### PR TITLE
Fixed usage of process.env.NODE_ENV

### DIFF
--- a/src/utils/renderProps.js
+++ b/src/utils/renderProps.js
@@ -10,10 +10,12 @@ const isFn = (prop) => typeof prop === 'function'
  */
 
 const renderProps = ({ children, render }, props) => {
-  warn(isFn(children) && isFn(render), `
-    You are using the children and render props together.
-    This is impossible, therefore, only the children will be used.
-  `)
+  if (process.env.NODE_ENV !== 'production') {
+    warn(isFn(children) && isFn(render),
+      'You are using the children and render props together.\n' +
+      'This is impossible, therefore, only the children will be used.'
+    )
+  }
 
   const fn = isFn(children)
     ? children

--- a/src/utils/warn.js
+++ b/src/utils/warn.js
@@ -1,11 +1,7 @@
 /* eslint-disable no-console */
 
-const hasEnv = process && process.env
-
-const isNotProd = hasEnv && process.env.NODE_ENV !== 'production'
-
 const warn = (condition, message, trace = true) => {
-  if (isNotProd && !!condition) {
+  if (!!condition) {
     console.warn(`[react-powerplug]: ${message}`)
     console.trace && trace && console.trace('Trace')
   }


### PR DESCRIPTION
This is how env should be used. It allows for better elimination of dead branches by minifiers and won't cause unnecessary `process` polyfills being added to consumers' bundles - bundlers should replace `process.env.NODE_ENV` on their own when bundling - there is no need for runtime checks in library's code.
