### PR TITLE
add webpack's "sideEffects: false" to package.json for efficient tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "build:flow": "cpy src/index.js.flow lib & cpy src/index.js.flow es",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",


### PR DESCRIPTION
Because of webpack/webpack#2867, webpack doesn't remove all unused code
when a user imports a single component from the library.


Webpack 4 fixes that for libraries that explicitly anounce thmeselves
to be side effect free:
https://github.com/webpack/webpack/tree/next/examples/side-effects.