### PR TITLE
Prefer react namespace import

### DIFF
--- a/src/components/Active.js
+++ b/src/components/Active.js
@@ -1,16 +1,18 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
 const Active = ({ onChange, ...props }) => (
-  <State initial={{ isActive: false }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      isActive: state.isActive,
-      bindActive: {
-        onMouseDown: () => setState({ isActive: true }),
-        onMouseUp: () => setState({ isActive: false }),
-      },
-    })}
+  <State initial={{ isActive: false }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        isActive: state.isActive,
+        bindActive: {
+          onMouseDown: () => setState({ isActive: true }),
+          onMouseUp: () => setState({ isActive: false }),
+        },
+      })
+    }
   </State>
 )
 

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,10 +1,10 @@
-import React from "react";
-import State from "./State";
-import renderProps from "../utils/renderProps";
+import * as React from 'react'
+import State from './State'
+import renderProps from '../utils/renderProps'
 
 const add = value => prev => ({
-  count: prev.count + value
-});
+  count: prev.count + value,
+})
 
 const Counter = ({ initial = 0, onChange, ...props }) => (
   <State initial={{ count: initial }} onChange={onChange}>
@@ -14,10 +14,10 @@ const Counter = ({ initial = 0, onChange, ...props }) => (
         inc: () => setState(add(1)),
         dec: () => setState(add(-1)),
         incBy: value => setState(add(value)),
-        decBy: value => setState(add(-value))
+        decBy: value => setState(add(-value)),
       })
     }
   </State>
-);
+)
 
-export default Counter;
+export default Counter

--- a/src/components/Focus.js
+++ b/src/components/Focus.js
@@ -1,16 +1,18 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
 const Focus = ({ onChange, ...props }) => (
-  <State initial={{ isFocus: false }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      isFocus: state.isFocus,
-      bindFocus: {
-        onFocusIn: () => setState({ isFocus: true }),
-        onFocusOut: () => setState({ isFocus: false }),
-      },
-    })}
+  <State initial={{ isFocus: false }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        isFocus: state.isFocus,
+        bindFocus: {
+          onFocusIn: () => setState({ isFocus: true }),
+          onFocusOut: () => setState({ isFocus: false }),
+        },
+      })
+    }
   </State>
 )
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 import set from '../utils/set'

--- a/src/components/Hover.js
+++ b/src/components/Hover.js
@@ -1,16 +1,18 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
 const Hover = ({ onChange, ...props }) => (
-  <State initial={{ isHover: false }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      isHover: state.isHover,
-      bindHover: {
-        onMouseEnter: () => setState({ isHover: true }),
-        onMouseLeave: () => setState({ isHover: false }),
-      },
-    })}
+  <State initial={{ isHover: false }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        isHover: state.isHover,
+        bindHover: {
+          onMouseEnter: () => setState({ isHover: true }),
+          onMouseLeave: () => setState({ isHover: false }),
+        },
+      })
+    }
   </State>
 )
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 import set from '../utils/set'

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,15 +1,17 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
 const Map = ({ initial = {}, onChange, ...props }) => (
-  <State initial={{ ...initial }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      values: state,
-      set: (key, value) => setState({ [key]: value }),
-      over: (key, fn) => setState(s => ({ [key]: fn(s[key]) })),
-      get: (key) => state[key],
-    })}
+  <State initial={{ ...initial }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        values: state,
+        set: (key, value) => setState({ [key]: value }),
+        over: (key, fn) => setState(s => ({ [key]: fn(s[key]) })),
+        get: key => state[key],
+      })
+    }
   </State>
 )
 

--- a/src/components/Set.js
+++ b/src/components/Set.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 import set from '../utils/set'

--- a/src/components/Value.js
+++ b/src/components/Value.js
@@ -1,13 +1,15 @@
-import React from 'react'
+import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
 const Value = ({ initial, onChange, ...props }) => (
-  <State initial={{ value: initial }} onChange={ onChange }>
-    {({ state, setState }) => renderProps(props, {
-      value: state.value,
-      setValue: (value) => setState({ value }),
-    })}
+  <State initial={{ value: initial }} onChange={onChange}>
+    {({ state, setState }) =>
+      renderProps(props, {
+        value: state.value,
+        setValue: value => setState({ value }),
+      })
+    }
   </State>
 )
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -106,7 +106,7 @@ type InputRender = ({|
   bind: {| value: string, onChange: (SyntheticInputEvent<*>) => void |},
 |}) => React.Node
 
-declare export var Bind: React.ComponentType<
+declare export var Input: React.ComponentType<
   | {| initial?: string, onChange?: InputChange, render: InputRender |}
   | {| initial?: string, onChange?: InputChange, children: InputRender |}
 >

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import renderProps from './renderProps'
 
 const isElement = element => typeof element.type === 'function'

--- a/tests/components/Active.test.js
+++ b/tests/components/Active.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Active } from '../../src'
 

--- a/tests/components/Compose.test.js
+++ b/tests/components/Compose.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Compose, Counter, Toggle } from '../../src'
 

--- a/tests/components/Counter.test.js
+++ b/tests/components/Counter.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Counter } from '../../src'
 import { last } from './utils'

--- a/tests/components/Focus.test.js
+++ b/tests/components/Focus.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Focus } from '../../src'
 

--- a/tests/components/Form.test.js
+++ b/tests/components/Form.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Form } from '../../src'
 

--- a/tests/components/Hover.test.js
+++ b/tests/components/Hover.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Hover } from '../../src'
 

--- a/tests/components/Input.test.js
+++ b/tests/components/Input.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Input } from '../../src'
 

--- a/tests/components/List.test.js
+++ b/tests/components/List.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { List } from '../../src'
 import { last } from './utils'

--- a/tests/components/Map.test.js
+++ b/tests/components/Map.test.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-console */
-
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Map } from '../../src'
 import { last } from './utils'

--- a/tests/components/Set.test.js
+++ b/tests/components/Set.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Set } from '../../src'
 import { last } from './utils'

--- a/tests/components/State.test.js
+++ b/tests/components/State.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { State } from '../../src'
 import { last } from './utils'

--- a/tests/components/Toggle.test.js
+++ b/tests/components/Toggle.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Toggle } from '../../src'
 import { last } from './utils'

--- a/tests/components/Value.test.js
+++ b/tests/components/Value.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Value } from '../../src'
 import { last } from './utils'

--- a/tests/test_flow.js
+++ b/tests/test_flow.js
@@ -150,7 +150,7 @@ const noop = () => null
   const render = ({ input }) => {
     const name = input('a')
     ;(name.value: string)
-    name.setValue('')
+    name.set('')
     ;(name.bind.value: string)
     ;(name.bind.onChange: Function)
     // $FlowFixMe


### PR DESCRIPTION
Currently react uses cjs under the hood but once they land esm version a lot of code will be broken because they will choose namespace exports over default one. I suggest to replace it today and do not care later.

Also in this PR fixed flow types and some code was prettified