### PR TITLE
Update Render Props for Toggle component in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ _If you want a more detailed **API Reference** and examples for each component s
 ### Toggle
 
 **Component Props:** `{ initial, onChange }`  
-**Render Props:** `{ on, off, toggle, setOn }`  
+**Render Props:** `{ on, toggle, set }`  
 [see docs](docs/components/Toggle.md)
 
 ```jsx


### PR DESCRIPTION
README.md is still making reference to the off and setOn props, which are no longer available.