### PR TITLE
Added two missing parentheses on Form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,28 +260,27 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 #### Form
 
 ```jsx
-<Form initial={{ subject: '', message: '' }}>
-  {({ input, values }) => (
-    <form onSubmit={(e) => {
-      e.preventDefault()
-      console.log(values)
-    }>
-      <ControlledInput
-        placeholder="Subject"
-        {...input('subject').bind}
-      />
-      <ControlledTextArea
-        placeholder="Message"
-        {...input('message').bind}
-      />
-      <Submit>Send</Submit>
-
-      {/*
-        input(id) => { bind, set, value }
-      */}
-    </form>
-  )
-</Form>
+  <Form initial={{ subject: '', message: '' }}>
+    {({ input, values }) => (
+      <form onSubmit={(e) => {
+        e.preventDefault()
+        console.log(values)
+      }}>
+        <ControlledInput
+          placeholder="Subject"
+          {...input('subject').bind}
+        />
+        <ControlledTextArea
+          placeholder="Message"
+          {...input('message').bind}
+        />
+        <Submit>Send</Submit>
+        {/*
+          input(id) => { bind, set, value }
+        */}
+      </form>
+    )}
+  </Form>
 ```
 
 # Composing Components


### PR DESCRIPTION
There was a missing parentheses missing after the console.log(values) and one missing just before the closing of the form. 
I'm not sure why the diff came out as such a large change, it was pretty small on my local as per attached. 
![image](https://user-images.githubusercontent.com/386035/38168915-d6702876-350f-11e8-9e6a-113a9535d0b0.png)
