### PR TITLE
add better warning to show that master is unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 - :books: Well documented
 - :beers: Bunch of awesome utilities
 
+## ⚠️ Master is unstable
+> This branch is **unstable** and is in **active development**.  
+> For the latest stable version go to [0.1-stable branch](https://github.com/renatorib/react-powerplug/tree/0.1-stable)
+
 <details>
   <summary>See quick examples</summary>
 
@@ -60,10 +64,7 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 
 ## Components
 
-> **_Note 1:_** This branch is **unstable** and is in **active development**.  
-> To the latest stable version go to [0.1-stable branch](https://github.com/renatorib/react-powerplug/tree/0.1-stable)
-
-> **_Note 2:_** _This is a kind of a cheat sheet for fast search._  
+> **_Note_** _This is a kind of a cheat sheet for fast search._  
 > _If you want a more detailed **API Reference** and examples for each component see [full docs](/docs)_
 
 | Component                    | Component Props         | Render Props                                   |                                                                             |


### PR DESCRIPTION
Hopefully fixes the recent issues with people not noticing that master is currently unstable and that the docs don't reflect the version installed from NPM.