### PR TITLE
Improve Updater<T> inference

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 /* Utils */
 
-type Updater<T> = (value: T | ((updater: T) => T)) => void
+type Updater<T> = (value: ((updater: T) => T) | T) => void
 
 /* Active */
 


### PR DESCRIPTION
Having that flow uses the first acceptable variant for inference and T match to function too, even we have right errors we can't use inference features like hover
See example (prev will be inferred right after this PR and as empty before)

Before PR:
![image](https://user-images.githubusercontent.com/5077042/39592792-8299a8d8-4f10-11e8-934f-b6f6969276a5.png)

After this PR:
![image](https://user-images.githubusercontent.com/5077042/39592737-5b126fb6-4f10-11e8-8f6c-90bdfde6d4d0.png)

cc @TrySound 
