### PR TITLE
Remove deprecated lifecycle from <Interval /> and fix its treeshaking

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-powerplug.umd.js": {
-    "bundled": 24185,
-    "minified": 10002,
-    "gzipped": 2571
+    "bundled": 24029,
+    "minified": 9906,
+    "gzipped": 2565
   },
   "dist/react-powerplug.cjs.js": {
-    "bundled": 21058,
-    "minified": 10885,
-    "gzipped": 2423
+    "bundled": 20918,
+    "minified": 10782,
+    "gzipped": 2414
   },
   "dist/react-powerplug.esm.js": {
-    "bundled": 20412,
-    "minified": 10336,
-    "gzipped": 2296,
+    "bundled": 20272,
+    "minified": 10233,
+    "gzipped": 2286,
     "treeshaked": {
-      "rollup": 3115,
-      "webpack": 3581
+      "rollup": 1489,
+      "webpack": 1939
     }
   }
 }

--- a/src/components/Interval.js
+++ b/src/components/Interval.js
@@ -2,10 +2,6 @@ import { Component } from 'react'
 import renderProps from '../utils/renderProps'
 
 class Interval extends Component {
-  static defaultProps = {
-    delay: 1000,
-  }
-
   state = {
     times: 0,
   }
@@ -32,7 +28,10 @@ class Interval extends Component {
   }
 
   start = delay => {
-    const _delay = typeof delay === 'number' ? delay : this.props.delay
+    const _delay =
+      typeof delay === 'number'
+        ? delay
+        : this.props.delay != null ? this.props.delay : 1000
     this._setIntervalIfNecessary(_delay)
   }
 
@@ -44,10 +43,10 @@ class Interval extends Component {
     this.start()
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.delay !== nextProps.delay) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.delay !== this.props.delay) {
       this.stop()
-      this.start(nextProps.delay)
+      this.start()
     }
   }
 


### PR DESCRIPTION
In this diff I replaced deprecated `componentWillReceiveProps` with
`componentDidUpdate` which should be used for side effects (which
implements this component).

To fix Interval component treeshakability I got rid from `defaultProps`
static property.

Ref #79 