### PR TITLE
use onMouseDown instead of setTimeout in FocusManager

### DIFF
--- a/src/components/FocusManager.js
+++ b/src/components/FocusManager.js
@@ -2,35 +2,40 @@ import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
 
-const FocusManager = ({ onChange, ...props }) => (
-  <State
-    initial={{ isFocused: false, timeoutId: null }}
-    onChange={({ isFocused }) => onChange && onChange({ isFocused })}
-  >
-    {({ state, setState }) =>
-      renderProps(props, {
-        isFocused: state.isFocused,
-        blur: () => {
-          setState({ isFocused: false })
-        },
-        bind: {
-          tabIndex: -1,
-          onBlur: () => {
-            // the timeoutId is saved in state to not cleanup in a rerender
-            setState({
-              timeoutId: setTimeout(() => {
+const FocusManager = ({ onChange, ...props }) => {
+  let canBlur = true
+  return (
+    <State
+      initial={{ isFocused: false }}
+      onChange={({ isFocused }) => onChange && onChange({ isFocused })}
+    >
+      {({ state, setState }) =>
+        renderProps(props, {
+          isFocused: state.isFocused,
+          blur: () => {
+            setState({ isFocused: false })
+          },
+          bind: {
+            tabIndex: -1,
+            onBlur: () => {
+              if (canBlur) {
                 setState({ isFocused: false })
-              }),
-            })
+              }
+            },
+            onFocus: () => {
+              setState({ isFocused: true })
+            },
+            onMouseDown: () => {
+              canBlur = false
+            },
+            onMouseUp: () => {
+              canBlur = true
+            },
           },
-          onFocus: () => {
-            clearTimeout(state.timeoutId)
-            setState({ isFocused: true })
-          },
-        },
-      })
-    }
-  </State>
-)
+        })
+      }
+    </State>
+  )
+}
 
 export default FocusManager


### PR DESCRIPTION
Came across some bugs recently at work with the `setTimeout` method and animations 😓, but it led me down a better path so I wanted to share it here 😇. Stoked to get rid of the hacky `setTimeout` so now everything should _just work_ as normal 🎉.