### PR TITLE
Remove args in console.trace

### DIFF
--- a/src/utils/warn.js
+++ b/src/utils/warn.js
@@ -3,7 +3,7 @@
 const warn = (condition, message, trace = true) => {
   if (condition) {
     console.warn(`[react-powerplug]: ${message}`)
-    console.trace && trace && console.trace('Trace')
+    console.trace && trace && console.trace()
   }
 }
 


### PR DESCRIPTION
Due to the MDN [document](https://developer.mozilla.org/en-US/docs/Web/API/Console/trace), there is no args when calling `console.trace()`.