### PR TITLE
fix Counter.set

### DIFF
--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import State from './State'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
 import onChangeProp from '../utils/onChangeProp'
 
 const add = value => state => ({
@@ -20,7 +19,7 @@ const Counter = ({ initial = 0, onChange, ...props }) => (
         dec: () => setState(add(-1)),
         incBy: value => setState(add(value)),
         decBy: value => setState(add(-value)),
-        set: value => setState(s => ({ on: set(value, s.on) })),
+        set: count => setState(() => ({ count })),
       })
     }
   </State>


### PR DESCRIPTION
The `set` function isn't working. It looks like it may have been taken from `Toggle` since it's setting the `on` state instead of updating `count`.