### PR TITLE
Omit is* word in components value

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/react-powerplug.umd.js": {
-    "bundled": 23769,
-    "minified": 9469,
-    "gzipped": 2596
+    "bundled": 23707,
+    "minified": 9407,
+    "gzipped": 2594
   },
   "dist/react-powerplug.cjs.js": {
-    "bundled": 20833,
-    "minified": 10881,
-    "gzipped": 2485
+    "bundled": 20771,
+    "minified": 10819,
+    "gzipped": 2483
   },
   "dist/react-powerplug.esm.js": {
-    "bundled": 20171,
-    "minified": 10321,
-    "gzipped": 2348,
+    "bundled": 20109,
+    "minified": 10259,
+    "gzipped": 2344,
     "treeshaked": {
       "rollup": {
         "code": 365,

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 | **\<Set>**                   | `{ initial, onChange }` | `{ values, add, clear, remove, has }`          | [:point_down:](#set) [:books:](docs/components/Set.md)                      |
 | **\<List>**                  | `{ initial, onChange }` | `{ list, first, last, push, pull, sort, set }` | [:point_down:](#list) [:books:](docs/components/List.md)                    |
 | <h6>FEEDBACK CONTAINERS</h6> |
-| **\<Hover>**                 | `{ onChange }`          | `{ isHovered, bind }`                          | [:point_down:](#hover) [:books:](docs/components/Hover.md)                  |
-| **\<Active>**                | `{ onChange }`          | `{ isActive, bind }`                           | [:point_down:](#active) [:books:](docs/components/Active.md)                |
-| **\<Focus>**                 | `{ onChange }`          | `{ isFocused, bind }`                          | [:point_down:](#focus) [:books:](docs/components/Focus.md)                  |
-| **\<Touch>**                 | `{ onChange }`          | `{ isTouched, bind }`                          | [:point_down:](#touch) [:books:](docs/components/Touch.md)                  |
-| **\<FocusManager>**          | `{ onChange }`          | `{ isFocused, blur, bind }`                    | [:point_down:](#focusmanager) [:books:](docs/components/FocusManager.md)    |
+| **\<Hover>**                 | `{ onChange }`          | `{ hovered, bind }`                            | [:point_down:](#hover) [:books:](docs/components/Hover.md)                  |
+| **\<Active>**                | `{ onChange }`          | `{ active, bind }`                             | [:point_down:](#active) [:books:](docs/components/Active.md)                |
+| **\<Focus>**                 | `{ onChange }`          | `{ focused, bind }`                            | [:point_down:](#focus) [:books:](docs/components/Focus.md)                  |
+| **\<Touch>**                 | `{ onChange }`          | `{ touched, bind }`                            | [:point_down:](#touch) [:books:](docs/components/Touch.md)                  |
+| **\<FocusManager>**          | `{ onChange }`          | `{ focused, blur, bind }`                      | [:point_down:](#focusmanager) [:books:](docs/components/FocusManager.md)    |
 | <h6>FORM CONTAINERS</h6>     |
 | **\<Input>**                 | `{ initial, onChange }` | `{ set, value, bind }`                         | [:point_down:](#input) [:books:](docs/components/Input.md)                  |
 | **\<Form>**                  | `{ initial, onChange }` | `{ input, values }`                            | [:point_down:](#form) [:books:](docs/components/Form.md)                    |
@@ -209,9 +209,9 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 
 ```jsx
 <Hover>
-  {({ isHovered, bind }) => (
+  {({ hovered, bind }) => (
     <div {...bind}>
-      You are {isHovered ? 'hovering' : 'not hovering'} this div.
+      You are {hovered ? 'hovering' : 'not hovering'} this div.
     </div>
   )}
 </Hover>
@@ -221,9 +221,9 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 
 ```jsx
 <Active>
-  {({ isActive, bind }) => (
+  {({ active, bind }) => (
     <div {...bind}>
-      You are {isActive ? 'clicking' : 'not clicking'} this div.
+      You are {active ? 'clicking' : 'not clicking'} this div.
     </div>
   )}
 </Active>
@@ -233,9 +233,9 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 
 ```jsx
 <Touch>
-  {({ isTouched, bind }) => (
+  {({ touched, bind }) => (
     <div {...bind}>
-      You are {isTouched ? 'touching' : 'not touching'} this div.
+      You are {touched ? 'touching' : 'not touching'} this div.
     </div>
   )}
 </Touch>
@@ -245,10 +245,10 @@ import { Pagination, Tabs, Checkbox } from './MyDumbComponents'
 
 ```jsx
 <Focus>
-  {({ isFocused, bind }) => (
+  {({ focused, bind }) => (
     <div>
       <input {...bind} placeholder="Focus me" />
-      <div>You are {isFocused ? 'focusing' : 'not focusing'} input.</div>
+      <div>You are {focused ? 'focusing' : 'not focusing'} input.</div>
     </div>
   )}
 </Focus>

--- a/docs/components/Active.md
+++ b/docs/components/Active.md
@@ -9,9 +9,9 @@ import { Active } from 'react-powerplug'
 
 ```jsx
 <Active>
-  {({ isActive, bind }) => (
+  {({ active, bind }) => (
     <div {...bind}>
-      You are {isActive ? 'clicking' : 'not clicking'} this div.
+      You are {active ? 'clicking' : 'not clicking'} this div.
     </div>
   )}
 </Active>
@@ -20,13 +20,13 @@ import { Active } from 'react-powerplug'
 ## Active Props
 
 **onChange** _(optional)_  
-The onChange event of the Active is called whenever the isActive state changes.
+The onChange event of the Active is called whenever the active state changes.
 
 ## Active Children Props
 
-TL;DR: `{ isActive, bind }`
+TL;DR: `{ active, bind }`
 
-**isActive**  
+**active**  
 `boolean`  
 True if is activated (being clicked) the binded element
 

--- a/docs/components/Focus.md
+++ b/docs/components/Focus.md
@@ -9,10 +9,10 @@ import { Focus } from 'react-powerplug'
 
 ```jsx
 <Focus>
-  {({ isFocused, bind }) => (
+  {({ focused, bind }) => (
     <div>
       <input {...bind} placeholder="Focus me" />
-      <div>You are {isFocused ? 'focusing' : 'not focusing'} the input.</div>
+      <div>You are {focused ? 'focusing' : 'not focusing'} the input.</div>
     </div>
   )}
 </Focus>
@@ -21,13 +21,13 @@ import { Focus } from 'react-powerplug'
 ## Focus Props
 
 **onChange** _(optional)_  
-The onChange event of the Focus is called whenever the isFocused state changes.
+The onChange event of the Focus is called whenever the focused state changes.
 
 ## Focus Children Props
 
-TL;DR: `{ isFocused, bind }`
+TL;DR: `{ focused, bind }`
 
-**isFocused**  
+**focused**  
 `boolean`  
 True if is focusing the binded element
 

--- a/docs/components/Hover.md
+++ b/docs/components/Hover.md
@@ -9,9 +9,9 @@ import { Hover } from 'react-powerplug'
 
 ```jsx
 <Hover>
-  {({ isHovered, bind }) => (
+  {({ hovered, bind }) => (
     <div {...bind}>
-      You are {isHovered ? 'hovering' : 'not hovering'} this div.
+      You are {hovered ? 'hovering' : 'not hovering'} this div.
     </div>
   )}
 </Hover>
@@ -20,13 +20,13 @@ import { Hover } from 'react-powerplug'
 ## Hover Props
 
 **onChange** _(optional)_  
-The onChange event of the Hover is called whenever the isHovered state changes.
+The onChange event of the Hover is called whenever the hovered state changes.
 
 ## Hover Children Props
 
-TL;DR: `{ isHovered, bind }`
+TL;DR: `{ hovered, bind }`
 
-**isHovered**  
+**hovered**  
 `boolean`  
 True if is hovering the binded element
 

--- a/docs/components/Touch.md
+++ b/docs/components/Touch.md
@@ -8,9 +8,9 @@ import { Touch } from 'react-powerplug'
 
 ```jsx
 <Touch>
-  {({ isTouched, bind }) => (
+  {({ touched, bind }) => (
     <div {...bind}>
-      You are {isTouched ? 'touching' : 'not touching'} this div.
+      You are {touched ? 'touching' : 'not touching'} this div.
     </div>
   )}
 </Touch>
@@ -19,13 +19,13 @@ import { Touch } from 'react-powerplug'
 ## Touch Props
 
 **onChange** _(optional)_  
-The onChange event of the Touch is called whenever the isTouched state changes.
+The onChange event of the Touch is called whenever the touched state changes.
 
 ## Touch Children Props
 
-TL;DR: `{ isTouched, bind }`
+TL;DR: `{ touched, bind }`
 
-**isTouched**  
+**touched**  
 `boolean`  
 True if is touching the binded element
 

--- a/docs/utils/composeEvents.md
+++ b/docs/utils/composeEvents.md
@@ -7,11 +7,11 @@ import { Hover, composeEvents } from 'react-powerplug'
 
 const HoveredDiv = ({ children, onMouseEnter, onMouseLeave, ...restProps }) => (
   <Hover>
-    {({ isHover, bindHover }) => (
+    {({ hovered, bindHover }) => (
       <div
         {...composeEvents({ onMouseEnter, onMouseLeave }, bindHover)}
         {...restProps}
-        children={children(isHover)}
+        children={children(hovered)}
       />
     )}
   </Hover>

--- a/src/components/Active.js
+++ b/src/components/Active.js
@@ -5,15 +5,15 @@ import onChangeProp from '../utils/onChangeProp'
 
 const Active = ({ onChange, ...props }) => (
   <State
-    initial={{ isActive: false }}
-    onChange={onChangeProp(onChange, 'isActive')}
+    initial={{ active: false }}
+    onChange={onChangeProp(onChange, 'active')}
   >
     {({ state, setState }) =>
       renderProps(props, {
-        isActive: state.isActive,
+        active: state.active,
         bind: {
-          onMouseDown: () => setState({ isActive: true }),
-          onMouseUp: () => setState({ isActive: false }),
+          onMouseDown: () => setState({ active: true }),
+          onMouseUp: () => setState({ active: false }),
         },
       })
     }

--- a/src/components/Focus.js
+++ b/src/components/Focus.js
@@ -5,15 +5,15 @@ import onChangeProp from '../utils/onChangeProp'
 
 const Focus = ({ onChange, ...props }) => (
   <State
-    initial={{ isFocused: false }}
-    onChange={onChangeProp(onChange, 'isFocused')}
+    initial={{ focused: false }}
+    onChange={onChangeProp(onChange, 'focused')}
   >
     {({ state, setState }) =>
       renderProps(props, {
-        isFocused: state.isFocused,
+        focused: state.focused,
         bind: {
-          onFocus: () => setState({ isFocused: true }),
-          onBlur: () => setState({ isFocused: false }),
+          onFocus: () => setState({ focused: true }),
+          onBlur: () => setState({ focused: false }),
         },
       })
     }

--- a/src/components/FocusManager.js
+++ b/src/components/FocusManager.js
@@ -7,24 +7,24 @@ const FocusManager = ({ onChange, ...props }) => {
   let canBlur = true
   return (
     <State
-      initial={{ isFocused: false }}
-      onChange={onChangeProp(onChange, 'isFocused')}
+      initial={{ focused: false }}
+      onChange={onChangeProp(onChange, 'focused')}
     >
       {({ state, setState }) =>
         renderProps(props, {
-          isFocused: state.isFocused,
+          focused: state.focused,
           blur: () => {
-            setState({ isFocused: false })
+            setState({ focused: false })
           },
           bind: {
             tabIndex: -1,
             onBlur: () => {
               if (canBlur) {
-                setState({ isFocused: false })
+                setState({ focused: false })
               }
             },
             onFocus: () => {
-              setState({ isFocused: true })
+              setState({ focused: true })
             },
             onMouseDown: () => {
               canBlur = false

--- a/src/components/Hover.js
+++ b/src/components/Hover.js
@@ -5,15 +5,15 @@ import onChangeProp from '../utils/onChangeProp'
 
 const Hover = ({ onChange, ...props }) => (
   <State
-    initial={{ isHovered: false }}
-    onChange={onChangeProp(onChange, 'isHovered')}
+    initial={{ hovered: false }}
+    onChange={onChangeProp(onChange, 'hovered')}
   >
     {({ state, setState }) =>
       renderProps(props, {
-        isHovered: state.isHovered,
+        hovered: state.hovered,
         bind: {
-          onMouseEnter: () => setState({ isHovered: true }),
-          onMouseLeave: () => setState({ isHovered: false }),
+          onMouseEnter: () => setState({ hovered: true }),
+          onMouseLeave: () => setState({ hovered: false }),
         },
       })
     }

--- a/src/components/Touch.js
+++ b/src/components/Touch.js
@@ -5,15 +5,15 @@ import onChangeProp from '../utils/onChangeProp'
 
 const Touch = ({ onChange, ...props }) => (
   <State
-    initial={{ isTouched: false }}
-    onChange={onChangeProp(onChange, 'isTouched')}
+    initial={{ touched: false }}
+    onChange={onChangeProp(onChange, 'touched')}
   >
     {({ state, setState }) =>
       renderProps(props, {
-        isTouched: state.isTouched,
+        touched: state.touched,
         bind: {
-          onTouchStart: () => setState({ isTouched: true }),
-          onTouchEnd: () => setState({ isTouched: false }),
+          onTouchStart: () => setState({ touched: true }),
+          onTouchEnd: () => setState({ touched: false }),
         },
       })
     }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -8,10 +8,10 @@ type Updater<T> = (value: ((updater: T) => T) | T) => void
 
 /* Active */
 
-type ActiveChange = (isActive: boolean) => void
+type ActiveChange = (active: boolean) => void
 
 type ActiveRender = ({|
-  isActive: boolean,
+  active: boolean,
   bind: {| onMouseDown: () => void, onMouseUp: () => void |},
 |}) => React.Node
 
@@ -43,10 +43,10 @@ declare export var Counter: React.ComponentType<
 
 /* Focus */
 
-type FocusChange = (isFocused: boolean) => void
+type FocusChange = (focused: boolean) => void
 
 type FocusRender = ({|
-  isFocused: boolean,
+  focused: boolean,
   bind: {| onFocus: () => void, onBlur: () => void |},
 |}) => React.Node
 
@@ -57,10 +57,10 @@ declare export var Focus: React.ComponentType<
 
 /* FocusManager */
 
-type FocusManagerChange = (isFocused: boolean) => void
+type FocusManagerChange = (focused: boolean) => void
 
 type FocusManagerRender = ({|
-  isFocused: boolean,
+  focused: boolean,
   blur: () => void,
   bind: {| tabIndex: number, onFocus: () => void, onBlur: () => void |},
 |}) => React.Node
@@ -99,10 +99,10 @@ declare export class Form<T: { [string]: string }> extends React.Component<
 
 /* Hover */
 
-type HoverChange = (isHovered: boolean) => void
+type HoverChange = (hovered: boolean) => void
 
 type HoverRender = ({|
-  isHovered: boolean,
+  hovered: boolean,
   bind: {| onMouseEnter: () => void, onMouseLeave: () => void |},
 |}) => React.Node
 
@@ -243,10 +243,10 @@ declare export var Toggle: React.ComponentType<
 
 /* Touch */
 
-type TouchChange = (isTouched: boolean) => void
+type TouchChange = (touched: boolean) => void
 
 type TouchRender = ({|
-  isTouched: boolean,
+  touched: boolean,
   bind: {| onTouchStart: () => void, onTouchEnd: () => void |},
 |}) => React.Node
 

--- a/tests/components/Active.test.js
+++ b/tests/components/Active.test.js
@@ -8,14 +8,14 @@ test('<Active />', () => {
   TestRenderer.create(<Active render={renderFn} />)
 
   expect(renderFn).toBeCalledTimes(1)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isActive: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ active: false }))
 
   lastCallArg(renderFn).bind.onMouseDown()
   expect(renderFn).toBeCalledTimes(2)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isActive: true }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ active: true }))
 
   lastCallArg(renderFn).bind.onMouseUp()
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isActive: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ active: false }))
 })
 
 test('<Active onChange />', () => {

--- a/tests/components/Focus.test.js
+++ b/tests/components/Focus.test.js
@@ -8,14 +8,14 @@ test('<Focus />', () => {
   TestRenderer.create(<Focus render={renderFn} />)
 
   expect(renderFn).toBeCalledTimes(1)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isFocused: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ focused: false }))
 
   lastCallArg(renderFn).bind.onFocus()
   expect(renderFn).toBeCalledTimes(2)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isFocused: true }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ focused: true }))
 
   lastCallArg(renderFn).bind.onBlur()
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isFocused: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ focused: false }))
 })
 
 test('<Focus onChange />', () => {

--- a/tests/components/FocusManager.test.js
+++ b/tests/components/FocusManager.test.js
@@ -52,12 +52,12 @@ test('keep focus when click on menu', async () => {
     const style = { width: 100, height: 100 }
     const App = () => (
       <FocusManager>
-        {({ isFocused, bind }) => {
-          window.renderFn({ isFocused })
+        {({ focused, bind }) => {
+          window.renderFn({ focused })
           return (
             <>
               <div id="rect-1" style={style} {...bind} />
-              {isFocused && <div id="rect-2" style={style} {...bind} />}
+              {focused && <div id="rect-2" style={style} {...bind} />}
             </>
           )
         }}
@@ -67,15 +67,15 @@ test('keep focus when click on menu', async () => {
     window.render(<App />)
   })
 
-  expect(renderFn).lastCalledWith({ isFocused: false })
+  expect(renderFn).lastCalledWith({ focused: false })
   await page.click('#rect-1')
-  expect(renderFn).lastCalledWith({ isFocused: true })
+  expect(renderFn).lastCalledWith({ focused: true })
   await page.click('#rect-2')
-  expect(renderFn).lastCalledWith({ isFocused: true })
+  expect(renderFn).lastCalledWith({ focused: true })
   // click outside
   await page.mouse.click(200, 50)
   await delay(100)
-  expect(renderFn).lastCalledWith({ isFocused: false })
+  expect(renderFn).lastCalledWith({ focused: false })
 })
 
 test('restore focus after calling blur on inner component', async () => {
@@ -91,8 +91,8 @@ test('restore focus after calling blur on inner component', async () => {
 
     const App = () => (
       <FocusManager onChange={window.onChangeFn}>
-        {({ isFocused, blur, bind }) => {
-          window.renderFn({ isFocused })
+        {({ focused, blur, bind }) => {
+          window.renderFn({ focused })
           const stopPropagation = e => e.stopPropagation()
           return (
             <>
@@ -114,14 +114,14 @@ test('restore focus after calling blur on inner component', async () => {
     window.render(<App />)
   })
 
-  expect(renderFn).lastCalledWith({ isFocused: false })
+  expect(renderFn).lastCalledWith({ focused: false })
   await page.click('#outer')
-  expect(renderFn).lastCalledWith({ isFocused: true })
+  expect(renderFn).lastCalledWith({ focused: true })
   expect(onChangeFn).lastCalledWith(true)
   await page.click('#inner')
-  expect(renderFn).lastCalledWith({ isFocused: false })
+  expect(renderFn).lastCalledWith({ focused: false })
   expect(onChangeFn).lastCalledWith(false)
   await page.click('#outer')
-  expect(renderFn).lastCalledWith({ isFocused: true })
+  expect(renderFn).lastCalledWith({ focused: true })
   expect(onChangeFn).lastCalledWith(true)
 })

--- a/tests/components/Hover.test.js
+++ b/tests/components/Hover.test.js
@@ -8,14 +8,14 @@ test('<Hover />', () => {
   TestRenderer.create(<Hover render={renderFn} />)
 
   expect(renderFn).toBeCalledTimes(1)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isHovered: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ hovered: false }))
 
   lastCallArg(renderFn).bind.onMouseEnter()
   expect(renderFn).toBeCalledTimes(2)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isHovered: true }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ hovered: true }))
 
   lastCallArg(renderFn).bind.onMouseLeave()
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isHovered: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ hovered: false }))
 })
 
 test('<Hover onChange />', () => {

--- a/tests/components/Touch.test.js
+++ b/tests/components/Touch.test.js
@@ -8,13 +8,13 @@ test('<Touch />', () => {
   TestRenderer.create(<Touch render={renderFn} />)
 
   expect(renderFn).toBeCalledTimes(1)
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isTouched: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ touched: false }))
 
   lastCallArg(renderFn).bind.onTouchStart()
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isTouched: true }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ touched: true }))
 
   lastCallArg(renderFn).bind.onTouchEnd()
-  expect(renderFn).lastCalledWith(expect.objectContaining({ isTouched: false }))
+  expect(renderFn).lastCalledWith(expect.objectContaining({ touched: false }))
 })
 
 test('<Touch onChange />', () => {

--- a/tests/test_flow.js
+++ b/tests/test_flow.js
@@ -24,22 +24,22 @@ const noop = () => null
 
 /* Active */
 {
-  const render = ({ isActive, bind }) => {
-    ;(isActive: boolean)
+  const render = ({ active, bind }) => {
+    ;(active: boolean)
     ;(bind.onMouseDown: Function)
     ;(bind.onMouseUp: Function)
     // $FlowFixMe
-    ;(isActive: number)
+    ;(active: number)
     // $FlowFixMe
     ;(bind.onMouseDown: number)
     // $FlowFixMe
     ;(bind.onMouseUp: number)
     return null
   }
-  const onChange = isActive => {
-    ;(isActive: boolean)
+  const onChange = active => {
+    ;(active: boolean)
     // $FlowFixMe
-    ;(isActive: number)
+    ;(active: number)
   }
   ;[
     <Active render={render} />,
@@ -153,22 +153,22 @@ const noop = () => null
 
 /* Focus */
 {
-  const render = ({ isFocused, bind }) => {
-    ;(isFocused: boolean)
+  const render = ({ focused, bind }) => {
+    ;(focused: boolean)
     ;(bind.onFocus: Function)
     ;(bind.onBlur: Function)
     // $FlowFixMe
-    ;(isFocused: number)
+    ;(focused: number)
     // $FlowFixMe
     ;(bind.onFocus: number)
     // $FlowFixMe
     ;(bind.onBlur: number)
     return null
   }
-  const onChange = isFocused => {
-    ;(isFocused: boolean)
+  const onChange = focused => {
+    ;(focused: boolean)
     // $FlowFixMe
-    ;(isFocused: number)
+    ;(focused: number)
   }
   ;[
     <Focus render={render} />,
@@ -182,23 +182,23 @@ const noop = () => null
 
 /* FocusManager */
 {
-  const render = ({ isFocused, blur, bind }) => {
-    ;(isFocused: boolean)
+  const render = ({ focused, blur, bind }) => {
+    ;(focused: boolean)
     ;(blur: Function)
     ;(bind.onFocus: Function)
     ;(bind.onBlur: Function)
     // $FlowFixMe
-    ;(isFocused: number)
+    ;(focused: number)
     // $FlowFixMe
     ;(bind.onFocus: number)
     // $FlowFixMe
     ;(bind.onBlur: number)
     return null
   }
-  const onChange = isFocused => {
-    ;(isFocused: boolean)
+  const onChange = focused => {
+    ;(focused: boolean)
     // $FlowFixMe
-    ;(isFocused: number)
+    ;(focused: number)
   }
   ;[
     <FocusManager render={render} />,
@@ -256,22 +256,22 @@ const noop = () => null
 
 /* Hover */
 {
-  const render = ({ isHovered, bind }) => {
-    ;(isHovered: boolean)
+  const render = ({ hovered, bind }) => {
+    ;(hovered: boolean)
     ;(bind.onMouseEnter: Function)
     ;(bind.onMouseLeave: Function)
     // $FlowFixMe
-    ;(isHovered: number)
+    ;(hovered: number)
     // $FlowFixMe
     ;(bind.onMouseEnter: number)
     // $FlowFixMe
     ;(bind.onMouseLeave: number)
     return null
   }
-  const onChange = isHovered => {
-    ;(isHovered: boolean)
+  const onChange = hovered => {
+    ;(hovered: boolean)
     // $FlowFixMe
-    ;(isHovered: number)
+    ;(hovered: number)
   }
   ;[
     <Hover render={render} />,
@@ -499,22 +499,22 @@ const noop = () => null
 
 /* Touch */
 {
-  const render = ({ isTouched, bind }) => {
-    ;(isTouched: boolean)
+  const render = ({ touched, bind }) => {
+    ;(touched: boolean)
     ;(bind.onTouchStart: Function)
     ;(bind.onTouchEnd: Function)
     // $FlowFixMe
-    ;(isTouched: number)
+    ;(touched: number)
     // $FlowFixMe
     ;(bind.onTouchStart: number)
     // $FlowFixMe
     ;(bind.onTouchEnd: number)
     return null
   }
-  const onChange = isTouched => {
-    ;(isTouched: boolean)
+  const onChange = touched => {
+    ;(touched: boolean)
     // $FlowFixMe
-    ;(isTouched: number)
+    ;(touched: number)
   }
   ;[
     <Touch render={render} />,


### PR DESCRIPTION
Ref https://github.com/renatorib/react-powerplug/issues/6#issuecomment-394385202

Thses names allow to distinguish values from functions.

isActive -> active
isFocused -> focused
isHovered -> hovered
isTouched -> touched