### PR TITLE
Provide natural blur command in FocusManager

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/react-powerplug.umd.js": {
-    "bundled": 23752,
-    "minified": 9415,
-    "gzipped": 2597
+    "bundled": 23776,
+    "minified": 9440,
+    "gzipped": 2612
   },
   "dist/react-powerplug.cjs.js": {
-    "bundled": 20814,
-    "minified": 10827,
-    "gzipped": 2486
+    "bundled": 20838,
+    "minified": 10852,
+    "gzipped": 2501
   },
   "dist/react-powerplug.esm.js": {
-    "bundled": 20152,
-    "minified": 10267,
-    "gzipped": 2349,
+    "bundled": 20176,
+    "minified": 10292,
+    "gzipped": 2366,
     "treeshaked": {
       "rollup": {
         "code": 365,

--- a/src/components/FocusManager.js
+++ b/src/components/FocusManager.js
@@ -14,7 +14,9 @@ const FocusManager = ({ onChange, ...props }) => {
         renderProps(props, {
           focused: state.focused,
           blur: () => {
-            setState({ focused: false })
+            if (state.focused) {
+              document.activeElement.blur()
+            }
           },
           bind: {
             tabIndex: -1,


### PR DESCRIPTION
This diff fixes a scenario with autocomplete when clicking on item
should close menu. After calling blur input focus is still on
and since menu state depends on it menu can't be enabled again without
clicking outside of it.

```js
<FocusManager>
  {manager =>
    <>
      <Input {...manager.bind} />
      <Menu {...manager.bind} onItemClick={manager.blur} />
    </>
  }
</FocusManager>
```

/cc @istarkov 