### PR TITLE
Change base component to Value

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-powerplug.umd.js": {
-    "bundled": 22187,
-    "minified": 8780,
-    "gzipped": 2415
+    "bundled": 20373,
+    "minified": 8144,
+    "gzipped": 2218
   },
   "dist/react-powerplug.cjs.js": {
-    "bundled": 20000,
-    "minified": 10012,
-    "gzipped": 2407
+    "bundled": 18338,
+    "minified": 9263,
+    "gzipped": 2228
   },
   "dist/react-powerplug.esm.js": {
-    "bundled": 19370,
-    "minified": 9474,
-    "gzipped": 2267,
+    "bundled": 17708,
+    "minified": 8725,
+    "gzipped": 2092,
     "treeshaked": {
       "rollup": {
-        "code": 204,
-        "import_statements": 204
+        "code": 197,
+        "import_statements": 197
       },
       "webpack": {
-        "code": 1506
+        "code": 1495
       }
     }
   }

--- a/src/components/Active.js
+++ b/src/components/Active.js
@@ -1,23 +1,19 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const Active = ({ onChange, ...props }) => (
-  <State
-    initial={{ active: false }}
-    onChange={onChangeProp(onChange, 'active')}
-  >
-    {({ state, setState }) =>
+  <Value initial={false} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        active: state.active,
+        active: value,
         bind: {
-          onMouseDown: () => setState({ active: true }),
-          onMouseUp: () => setState({ active: false }),
+          onMouseDown: () => set(true),
+          onMouseUp: () => set(false),
         },
       })
     }
-  </State>
+  </Value>
 )
 
 export default Active

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,29 +1,22 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
-import onChangeProp from '../utils/onChangeProp'
 
-const add = value => state => ({
-  count: state.count + value,
-})
+const add = diff => value => value + diff
 
 const Counter = ({ initial = 0, onChange, ...props }) => (
-  <State
-    initial={{ count: initial }}
-    onChange={onChangeProp(onChange, 'count')}
-  >
-    {({ state, setState }) =>
+  <Value initial={initial} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        count: state.count,
-        inc: () => setState(add(1)),
-        dec: () => setState(add(-1)),
-        incBy: value => setState(add(value)),
-        decBy: value => setState(add(-value)),
-        set: value => setState(s => ({ count: set(value, s.count) })),
+        count: value,
+        inc: () => set(add(1)),
+        dec: () => set(add(-1)),
+        incBy: value => set(add(value)),
+        decBy: value => set(add(-value)),
+        set: value => set(value),
       })
     }
-  </State>
+  </Value>
 )
 
 export default Counter

--- a/src/components/Focus.js
+++ b/src/components/Focus.js
@@ -1,23 +1,19 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const Focus = ({ onChange, ...props }) => (
-  <State
-    initial={{ focused: false }}
-    onChange={onChangeProp(onChange, 'focused')}
-  >
-    {({ state, setState }) =>
+  <Value initial={false} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        focused: state.focused,
+        focused: value,
         bind: {
-          onFocus: () => setState({ focused: true }),
-          onBlur: () => setState({ focused: false }),
+          onFocus: () => set(true),
+          onBlur: () => set(false),
         },
       })
     }
-  </State>
+  </Value>
 )
 
 export default Focus

--- a/src/components/FocusManager.js
+++ b/src/components/FocusManager.js
@@ -1,20 +1,16 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const FocusManager = ({ onChange, ...props }) => {
   let canBlur = true
   return (
-    <State
-      initial={{ focused: false }}
-      onChange={onChangeProp(onChange, 'focused')}
-    >
-      {({ state, setState }) =>
+    <Value initial={false} onChange={onChange}>
+      {({ value, set }) =>
         renderProps(props, {
-          focused: state.focused,
+          focused: value,
           blur: () => {
-            if (state.focused) {
+            if (value) {
               document.activeElement.blur()
             }
           },
@@ -22,11 +18,11 @@ const FocusManager = ({ onChange, ...props }) => {
             tabIndex: -1,
             onBlur: () => {
               if (canBlur) {
-                setState({ focused: false })
+                set(false)
               }
             },
             onFocus: () => {
-              setState({ focused: true })
+              set(true)
             },
             onMouseDown: () => {
               canBlur = false
@@ -37,7 +33,7 @@ const FocusManager = ({ onChange, ...props }) => {
           },
         })
       }
-    </State>
+    </Value>
   )
 }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,29 +1,31 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
 
 const Form = ({ initial = {}, onChange, ...props }) => (
-  <State initial={{ ...initial }} onChange={onChange}>
-    {({ state, setState }) =>
+  <Value initial={{ ...initial }} onChange={onChange}>
+    {({ value: values, set }) =>
       renderProps(props, {
-        values: { ...state },
+        values,
         input: id => {
-          const value = state[id] || ''
-          const setValue = value => setState({ [id]: value })
+          const value = values[id] || ''
+          const setValue = updater =>
+            typeof updater === 'function'
+              ? set(prev => ({ ...prev, [id]: updater(prev[id]) }))
+              : set({ ...values, [id]: updater })
 
           return {
-            bind: {
-              onChange: event => setValue(event.target.value),
-              value,
-            },
-            set: value => setState(s => ({ [id]: set(value, s.value) })),
             value,
+            set: setValue,
+            bind: {
+              value,
+              onChange: event => setValue(event.target.value),
+            },
           }
         },
       })
     }
-  </State>
+  </Value>
 )
 
 export default Form

--- a/src/components/Hover.js
+++ b/src/components/Hover.js
@@ -1,23 +1,19 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const Hover = ({ onChange, ...props }) => (
-  <State
-    initial={{ hovered: false }}
-    onChange={onChangeProp(onChange, 'hovered')}
-  >
-    {({ state, setState }) =>
+  <Value initial={false} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        hovered: state.hovered,
+        hovered: value,
         bind: {
-          onMouseEnter: () => setState({ hovered: true }),
-          onMouseLeave: () => setState({ hovered: false }),
+          onMouseEnter: () => set(true),
+          onMouseLeave: () => set(false),
         },
       })
     }
-  </State>
+  </Value>
 )
 
 export default Hover

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,25 +1,20 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
-import onChangeProp from '../utils/onChangeProp'
 
 const Input = ({ initial = '', onChange, ...props }) => (
-  <State
-    initial={{ value: initial }}
-    onChange={onChangeProp(onChange, 'value')}
-  >
-    {({ state, setState }) =>
+  <Value initial={initial} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
+        value,
+        set: value => set(value),
         bind: {
-          onChange: event => setState({ value: event.target.value }),
-          value: state.value,
+          value,
+          onChange: event => set(event.target.value),
         },
-        set: value => setState(s => ({ value: set(value, s.value) })),
-        value: state.value,
       })
     }
-  </State>
+  </Value>
 )
 
 export default Input

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,27 +1,23 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
-import onChangeProp from '../utils/onChangeProp'
 
 const complement = fn => (...args) => !fn(...args)
 
 const List = ({ initial = [], onChange, ...props }) => (
-  <State initial={{ list: initial }} onChange={onChangeProp(onChange, 'list')}>
-    {({ state, setState }) =>
+  <Value initial={initial} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        list: state.list,
-        first: () => state.list[0],
-        last: () => state.list[Math.max(0, state.list.length - 1)],
-        set: list => setState(s => ({ list: set(list, s.list) })),
-        push: (...values) => setState(s => ({ list: [...s.list, ...values] })),
-        pull: predicate =>
-          setState(s => ({ list: s.list.filter(complement(predicate)) })),
-        sort: compareFn =>
-          setState(s => ({ list: [...s.list].sort(compareFn) })),
+        list: value,
+        first: () => value[0],
+        last: () => value[Math.max(0, value.length - 1)],
+        set: list => set(list),
+        push: (...values) => set(list => [...list, ...values]),
+        pull: predicate => set(list => list.filter(complement(predicate))),
+        sort: compareFn => set(list => [...list].sort(compareFn)),
       })
     }
-  </State>
+  </Value>
 )
 
 export default List

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,18 +1,18 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
 
 const Map = ({ initial = {}, onChange, ...props }) => (
-  <State initial={{ ...initial }} onChange={onChange}>
-    {({ state, setState }) =>
+  <Value initial={{ ...initial }} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        values: state,
-        set: (key, value) => setState({ [key]: value }),
-        over: (key, fn) => setState(s => ({ [key]: fn(s[key]) })),
-        get: key => state[key],
+        values: value,
+        set: (key, value) => set(prev => ({ ...prev, [key]: value })),
+        over: (key, fn) => set(prev => ({ ...prev, [key]: fn(prev[key]) })),
+        get: key => value[key],
       })
     }
-  </State>
+  </Value>
 )
 
 export default Map

--- a/src/components/Set.js
+++ b/src/components/Set.js
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const unique = arr => arr.filter((d, i) => arr.indexOf(d) === i)
 const hasItem = (arr, item) => arr.indexOf(item) !== -1
@@ -10,20 +9,17 @@ const removeItem = (arr, item) =>
 const addUnique = (arr, item) => (hasItem(arr, item) ? arr : [...arr, item])
 
 const Set = ({ initial = [], onChange, ...props }) => (
-  <State
-    initial={{ values: unique(initial) }}
-    onChange={onChangeProp(onChange, 'values')}
-  >
-    {({ state, setState }) =>
+  <Value initial={unique(initial)} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        values: state.values,
-        add: key => setState({ values: addUnique(state.values, key) }),
-        clear: () => setState({ values: [] }),
-        remove: key => setState({ values: removeItem(state.values, key) }),
-        has: key => hasItem(state.values, key),
+        values: value,
+        add: key => set(values => addUnique(values, key)),
+        clear: () => set([]),
+        remove: key => set(values => removeItem(values, key)),
+        has: key => hasItem(value, key),
       })
     }
-  </State>
+  </Value>
 )
 
 export default Set

--- a/src/components/State.js
+++ b/src/components/State.js
@@ -1,27 +1,19 @@
-import { Component } from 'react'
+import * as React from 'react'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import noop from '../utils/noop'
 
-class State extends Component {
-  state = {
-    ...this.props.initial,
-  }
-
-  _setState = (updater, cb = noop) => {
-    const { onChange = noop } = this.props
-
-    this.setState(updater, () => {
-      onChange(this.state)
-      cb()
-    })
-  }
-
-  render() {
-    return renderProps(this.props, {
-      state: this.state,
-      setState: this._setState,
-    })
-  }
-}
+const State = ({ initial = {}, onChange, ...props }) => (
+  <Value initial={initial} onChange={onChange}>
+    {({ value, set }) =>
+      renderProps(props, {
+        state: value,
+        setState: (updater, cb) =>
+          typeof updater === 'function'
+            ? set(prev => ({ ...prev, ...updater(prev) }), cb)
+            : set({ ...value, ...updater }, cb),
+      })
+    }
+  </Value>
+)
 
 export default State

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -1,19 +1,17 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
-import onChangeProp from '../utils/onChangeProp'
 
 const Toggle = ({ initial = false, onChange, ...props }) => (
-  <State initial={{ on: initial }} onChange={onChangeProp(onChange, 'on')}>
-    {({ state, setState }) =>
+  <Value initial={initial} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        on: state.on,
-        toggle: () => setState(s => ({ on: !s.on })),
-        set: value => setState(s => ({ on: set(value, s.on) })),
+        on: value,
+        toggle: () => set(on => !on),
+        set: value => set(value),
       })
     }
-  </State>
+  </Value>
 )
 
 export default Toggle

--- a/src/components/Touch.js
+++ b/src/components/Touch.js
@@ -1,23 +1,19 @@
 import * as React from 'react'
-import State from './State'
+import Value from './Value'
 import renderProps from '../utils/renderProps'
-import onChangeProp from '../utils/onChangeProp'
 
 const Touch = ({ onChange, ...props }) => (
-  <State
-    initial={{ touched: false }}
-    onChange={onChangeProp(onChange, 'touched')}
-  >
-    {({ state, setState }) =>
+  <Value initial={false} onChange={onChange}>
+    {({ value, set }) =>
       renderProps(props, {
-        touched: state.touched,
+        touched: value,
         bind: {
-          onTouchStart: () => setState({ touched: true }),
-          onTouchEnd: () => setState({ touched: false }),
+          onTouchStart: () => set(true),
+          onTouchEnd: () => set(false),
         },
       })
     }
-  </State>
+  </Value>
 )
 
 export default Touch

--- a/src/components/Value.js
+++ b/src/components/Value.js
@@ -1,21 +1,33 @@
-import * as React from 'react'
-import State from './State'
+import { Component } from 'react'
 import renderProps from '../utils/renderProps'
-import set from '../utils/set'
-import onChangeProp from '../utils/onChangeProp'
 
-const Value = ({ initial, onChange, ...props }) => (
-  <State
-    initial={{ value: initial }}
-    onChange={onChangeProp(onChange, 'value')}
-  >
-    {({ state, setState }) =>
-      renderProps(props, {
-        value: state.value,
-        set: value => setState(s => ({ value: set(value, s.value) })),
-      })
-    }
-  </State>
-)
+const noop = () => {}
+
+class Value extends Component {
+  state = {
+    value: this.props.initial,
+  }
+
+  _set = (updater, cb = noop) => {
+    const { onChange = noop } = this.props
+
+    this.setState(
+      typeof updater === 'function'
+        ? state => ({ value: updater(state.value) })
+        : { value: updater },
+      () => {
+        onChange(this.state.value)
+        cb()
+      }
+    )
+  }
+
+  render() {
+    return renderProps(this.props, {
+      value: this.state.value,
+      set: this._set,
+    })
+  }
+}
 
 export default Value

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 /* Utils */
 
-type Updater<T> = (value: ((updater: T) => T) | T) => void
+type Updater<T> = (updater: (T => T) | T) => void
 
 /* Active */
 
@@ -209,7 +209,7 @@ type StateChange<T> = T => void
 
 type StateRender<T> = ({|
   state: T,
-  setState: (updated: $Shape<T> | (T => $Shape<T>), cb?: () => void) => void,
+  setState: (updater: (T => $Shape<T>) | $Shape<T>, cb?: () => void) => void,
 |}) => React.Node
 
 type StateProps<T> =

--- a/src/utils/noop.js
+++ b/src/utils/noop.js
@@ -1,2 +1,0 @@
-const noop = () => {}
-export default noop

--- a/src/utils/onChangeProp.js
+++ b/src/utils/onChangeProp.js
@@ -1,7 +1,0 @@
-import noop from './noop'
-
-const onChangeProp = (originalOnChange = noop, propName) => state => {
-  originalOnChange(state[propName])
-}
-
-export default onChangeProp

--- a/src/utils/set.js
+++ b/src/utils/set.js
@@ -1,4 +1,0 @@
-const set = (updater, arg) =>
-  typeof updater === 'function' ? updater(arg) : updater
-
-export default set

--- a/tests/components/State.test.js
+++ b/tests/components/State.test.js
@@ -5,6 +5,7 @@ import { lastCallArg } from './utils'
 
 test('<State />', () => {
   const renderFn = jest.fn().mockReturnValue(null)
+  const callbackFn = jest.fn()
   TestRenderer.create(<State initial={{ myValue: 1 }} render={renderFn} />)
 
   // Initial values
@@ -20,6 +21,12 @@ test('<State />', () => {
     state: { myValue: 2 },
     setState: expect.any(Function),
   })
+
+  // call callback only once
+  lastCallArg(renderFn).setState({ myValue: 3 }, callbackFn)
+  expect(callbackFn).toBeCalledTimes(1)
+  lastCallArg(renderFn).setState({ myValue: 4 })
+  expect(callbackFn).toBeCalledTimes(1)
 })
 
 test('<State onChange />', () => {

--- a/tests/test_flow.js
+++ b/tests/test_flow.js
@@ -421,7 +421,7 @@ const noop = () => null
 {
   const render = ({ state, setState }) => {
     ;(state.v: number)
-    setState({})
+    setState({}, () => {})
     setState({ v: 1 })
     // $FlowFixMe
     ;(state.v: string)


### PR DESCRIPTION
`<State />` component has too much own logic which makes `State` based
components more complex with additional `set` and `onChangeProp`
helpers.

In this diff I reimplemented `<Value />` as class and `<State />` and
another components as `Value` based.

This reduced bundle size with ~0.8kb (parsed) and significantly
simplified components implementation.