### PR TITLE
Add initial prop to set and setState

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/react-powerplug.umd.js": {
-    "bundled": 20373,
-    "minified": 8144,
-    "gzipped": 2218
+    "bundled": 20409,
+    "minified": 8160,
+    "gzipped": 2224
   },
   "dist/react-powerplug.cjs.js": {
-    "bundled": 18338,
-    "minified": 9263,
-    "gzipped": 2228
+    "bundled": 18374,
+    "minified": 9279,
+    "gzipped": 2234
   },
   "dist/react-powerplug.esm.js": {
-    "bundled": 17708,
-    "minified": 8725,
-    "gzipped": 2092,
+    "bundled": 17744,
+    "minified": 8741,
+    "gzipped": 2098,
     "treeshaked": {
       "rollup": {
         "code": 197,

--- a/docs/components/State.md
+++ b/docs/components/State.md
@@ -37,5 +37,5 @@ TL;DR: `{ state, setState }`
 Your state
 
 **setState**  
-`(object | (state: object) => object) => void`  
+`(object | (state: object, initialProp: object) => object) => void`  
 State setter. Is the [setState](https://facebook.github.io/react/docs/react-component.html#setstate) from React.Component.

--- a/docs/components/Value.md
+++ b/docs/components/Value.md
@@ -55,5 +55,5 @@ TL;DR: `{ value, set }`
 Your value state
 
 **set**  
-`(value: T | (value: T) => T) => void`  
+`(value: T | (value: T, initialProp: T) => T) => void`  
 Set or over the value state

--- a/src/components/State.js
+++ b/src/components/State.js
@@ -9,7 +9,7 @@ const State = ({ initial = {}, onChange, ...props }) => (
         state: value,
         setState: (updater, cb) =>
           typeof updater === 'function'
-            ? set(prev => ({ ...prev, ...updater(prev) }), cb)
+            ? set((prev, props) => ({ ...prev, ...updater(prev, props) }), cb)
             : set({ ...value, ...updater }, cb),
       })
     }

--- a/src/components/Value.js
+++ b/src/components/Value.js
@@ -13,7 +13,7 @@ class Value extends Component {
 
     this.setState(
       typeof updater === 'function'
-        ? state => ({ value: updater(state.value) })
+        ? (state, props) => ({ value: updater(state.value, props.initial) })
         : { value: updater },
       () => {
         onChange(this.state.value)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -209,7 +209,10 @@ type StateChange<T> = T => void
 
 type StateRender<T> = ({|
   state: T,
-  setState: (updater: (T => $Shape<T>) | $Shape<T>, cb?: () => void) => void,
+  setState: (
+    updater: ((T, T) => $Shape<T>) | $Shape<T>,
+    cb?: () => void
+  ) => void,
 |}) => React.Node
 
 type StateProps<T> =
@@ -267,7 +270,7 @@ type ValueChange<T> = (value: T) => void
 
 type ValueRender<T> = ({|
   value: T,
-  set: Updater<T>,
+  set: (updater: ((T, T) => T) | T) => void,
 |}) => React.Node
 
 type ValueProps<T> =

--- a/tests/components/State.test.js
+++ b/tests/components/State.test.js
@@ -6,7 +6,9 @@ import { lastCallArg } from './utils'
 test('<State />', () => {
   const renderFn = jest.fn().mockReturnValue(null)
   const callbackFn = jest.fn()
-  TestRenderer.create(<State initial={{ myValue: 1 }} render={renderFn} />)
+  const testRenderer = TestRenderer.create(
+    <State initial={{ myValue: 1 }} render={renderFn} />
+  )
 
   // Initial values
   expect(renderFn).lastCalledWith({
@@ -27,6 +29,19 @@ test('<State />', () => {
   expect(callbackFn).toBeCalledTimes(1)
   lastCallArg(renderFn).setState({ myValue: 4 })
   expect(callbackFn).toBeCalledTimes(1)
+  expect(renderFn).lastCalledWith(
+    expect.objectContaining({ state: { myValue: 4 } })
+  )
+
+  testRenderer.update(<State initial={{ myValue: 101 }} render={renderFn} />)
+  expect(renderFn).lastCalledWith(
+    expect.objectContaining({ state: { myValue: 4 } })
+  )
+
+  lastCallArg(renderFn).setState((_, initial) => initial)
+  expect(renderFn).lastCalledWith(
+    expect.objectContaining({ state: { myValue: 101 } })
+  )
 })
 
 test('<State onChange />', () => {

--- a/tests/components/Value.test.js
+++ b/tests/components/Value.test.js
@@ -5,7 +5,9 @@ import { lastCallArg } from './utils'
 
 test('<Value />', () => {
   const renderFn = jest.fn().mockReturnValue(null)
-  TestRenderer.create(<Value initial={{ a: 1 }} render={renderFn} />)
+  const testRenderer = TestRenderer.create(
+    <Value initial={{ a: 1 }} render={renderFn} />
+  )
 
   expect(renderFn).toBeCalledTimes(1)
 
@@ -21,6 +23,16 @@ test('<Value />', () => {
 
   lastCallArg(renderFn).set(0)
   expect(renderFn).lastCalledWith(expect.objectContaining({ value: 0 }))
+
+  // check that it's possible to reset
+  const callsNum = renderFn.mock.calls.length
+  testRenderer.update(<Value initial={101} render={renderFn} />)
+  expect(renderFn.mock.calls.length).toBe(callsNum + 1)
+
+  expect(renderFn).lastCalledWith(expect.objectContaining({ value: 0 }))
+
+  lastCallArg(renderFn).set((_, initial) => initial)
+  expect(renderFn).lastCalledWith(expect.objectContaining({ value: 101 }))
 })
 
 test('<Value onChange />', () => {

--- a/tests/test_flow.js
+++ b/tests/test_flow.js
@@ -470,6 +470,25 @@ const noop = () => null
   ]
 }
 
+{
+  const render2 = ({ state, setState }) => {
+    setState({ n: 1 })
+    setState(() => {
+      n: 1
+    })
+    setState((_, x) => {
+      n: x.n
+    })
+    ;(state.n: number)
+    // $FlowFixMe
+    ;(state.n: string)
+  }
+  ;[
+    <State initial={{ n: 1 }} render={render2} />,
+    <State initial={{ n: 1 }}>{render2}</State>,
+  ]
+}
+
 /* Toggle */
 {
   const render = ({ on, toggle, set }) => {
@@ -577,4 +596,18 @@ const noop = () => null
     <Value initial={(0: number)} render={render1} />,
     <Value initial={(0: number)}>{render1}</Value>,
   ]
+}
+
+/* Value with specified generic */
+{
+  const render2 = ({ value, set }) => {
+    set(1)
+    set(x => x + 1)
+    set((_, x) => x + 1)
+    ;(value: number)
+
+    // $FlowFixMe
+    ;(value: string)
+  }
+  ;[<Value initial={0}>{render2}</Value>]
 }


### PR DESCRIPTION
This allows to reset state to initial prop, making updater api more similar to React setState api,
and it is less breaking change vs prev PR if anyone (i.e. I'm) used undocumented feature of setState updater function.

So before it was possible to call
```
<State initial={blabla}>{
  ({state, setState} => 
      ... => setState((_, {initial}) => initial )
...
```

Same code now will look like 
```
<State initial={blabla}>{
  ({state, setState} => 
      ... => setState((_, initial) => initial )
...
```

Same is possible for Value too

ref https://github.com/renatorib/react-powerplug/pull/148
ref https://github.com/renatorib/react-powerplug/issues/110#issuecomment-411932761